### PR TITLE
Error prevention

### DIFF
--- a/lua/ulx/xgui/gamemodes/terrortown.lua
+++ b/lua/ulx/xgui/gamemodes/terrortown.lua
@@ -1516,7 +1516,7 @@ end
 
 hook.Add("InitPostEntity", "CustomRolesLocalLoad", function()
     -- Force a delay to allow the replicated cvars to be created
-    timer.Simple(8, function()
+    timer.Simple(10, function()
         AddRoundStructureModule()
         AddGameplayModule()
         AddKarmaModule()


### PR DESCRIPTION
- Increase load delay to avoid error due to replicated convars not existing yet
- Changed dynamic convar creation to have inaccurate labels and bounds rather than error when the convars don't exist yet